### PR TITLE
Bug fix in addrmgr.Good(addr *wire.NetAddress)

### DIFF
--- a/addrmgr/addrmanager.go
+++ b/addrmgr/addrmanager.go
@@ -879,12 +879,12 @@ func (a *AddrManager) Good(addr *wire.NetAddress) {
 			}
 		}
 	}
-	a.nNew--
 
 	if oldBucket == -1 {
 		// What? wasn't in a bucket after all.... Panic?
 		return
 	}
+	a.nNew--
 
 	bucket := a.getTriedBucket(ka.na)
 


### PR DESCRIPTION
This function has a check as to whether the input address exists in any of the new address buckets. If it does not, the function returns. However, the function decrements nNew before performing this check. If an address was passed to Good that was not in any new address bucket, then the function would falsely decriment its count of new addresses even if Good did not remove any new address. I moved the decrement so that it is after the check.
